### PR TITLE
Add rosdep on libjsoncpp-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -46,6 +46,7 @@
   <!-- <build_depend>libjingle-dev</build_depend> -->
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>libjsoncpp-dev</build_depend>
   
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Since this has a defined rosdep. This will allow the removal of the line here: https://github.com/mayfieldrobotics/embedded-ansible/blob/837de2de7bdb9a2f09ceb47487824771dbced16b/ansible/roles/robot2020/tasks/main.yml#L11
