### PR TITLE
support fs video devices

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -113,14 +113,17 @@ bool Config::_get(ros::NodeHandle& nh, const std::string& root, VideoSource& val
     if (!nh.getParam(ros::names::append(root, "name"), value.name)) {
         return false;
     }
-    if (value.name.find("sys://") == 0) {
-        value.name = value.name.substr(6);
-        value.type = VideoSource::SystemType;
+    if (value.name.find("name://") == 0) {
+        value.name = value.name.substr(7);
+        value.type = VideoSource::NameType;
+    } else if (value.name.find("id://") == 0) {
+        value.name = value.name.substr(5);
+        value.type = VideoSource::IdType;
     } else if (value.name.find("ros://") == 0) {
         value.name = value.name.substr(6);
         value.type = VideoSource::ROSType;
     } else {
-        value.type = VideoSource::SystemType;
+        value.type = VideoSource::NameType;
     }
     nh.getParam(ros::names::append(root, "label"), value.label);
     if (!_get(nh, ros::names::append(root, "constraints"), value.constraints)) {

--- a/src/config.h
+++ b/src/config.h
@@ -25,11 +25,17 @@ public:
 
        cameras:
         downward:
+          # video device is ROS sensor_msgs/Image topic
           name: ros:///downward_looking_camera/image_raw
           label: downward
         upward:
-          name: ros:///upward_looking_camera/image_raw
+          # video device is file-system path
+          name: id:///dev/upward_looking_camera
           label: upward
+        wayward:
+          # video device is system dependent name (e.g. Linux 2.6+ its `cat /sys/class/video4linux/video{#}/name`)
+          name: HD Camera
+          label: wayward
        session:
         constraints:
           optional:

--- a/src/host.h
+++ b/src/host.h
@@ -21,8 +21,8 @@
 struct VideoSource {
 
     enum Type {
-        NoneType = 0,
-        SystemType,
+        NameType = 0,
+        IdType,
         ROSType
     };
 


### PR DESCRIPTION
video device resolve is now based on leading scheme:
- `name://`{name} (e.g. on linux {name} is v4l2 enumerated card type)
- `id://`{/dev/path} (e.g. /dev/video0)
- `ros://`{/topic/name} (e.g. any sensor_mgs/Image topic)

default scheme is `name://`

closes #34
