### PR TITLE
Adding depends on libjingle.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -47,10 +47,12 @@
   <build_depend>libjsoncpp-dev</build_depend>
   <build_depend>bondcpp</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>libjingle</build_depend>
   
   <run_depend>cv_bridge</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>libjingle</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
This change needs this change to work:

https://github.com/mayfieldrobotics/embedded-ansible/commit/45b7addcad6e09b7e0b052a44b9ab04baf111b61

With the mayfiled rodsep installed, you should be able to run "rosdep resolve libjingle" to get a list of the satisfying packages.
