### PR TITLE
remove error in js, README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ http://localhost:8080/#cd0bdd0b147c4ba4bea16ca3cb35c140/wait
 and call it from `ros_webrtc_example`:
 
 ```bash
-~/tmp/ros-webrtc-ws$ rosservice call /ros_webrtc/example/call cd0bdd0b147c4ba4bea16ca3cb35c140 ''
+~/tmp/ros-webrtc-ws$ rosservice call /ros_webrtc_example/example/call cd0bdd0b147c4ba4bea16ca3cb35c140 ''
 ```
 
 where:

--- a/test/fixtures/site/src/ros_webrtc.js
+++ b/test/fixtures/site/src/ros_webrtc.js
@@ -128,6 +128,7 @@ ros_webrtc.Signaling = Backbone.Model.extend({
           add_ice_candidate: this._onAddIceCandidate,
           set_session_description: this._onSetSessionDescription,
           hangup: this._onHangup,
+          connect: function(){},
         }[msg.type];
     handler.call(this, msg);
   },


### PR DESCRIPTION
Hi there, thank you so much for open sourcing this library! Its been a great help in getting teleop, video, and audio transmission going for our robot :)

I noticed a couple typos as I was integrating the code, so figured I'd PR them back to your repo.

Also noticed that this file:
https://github.com/mayfieldrobotics/ros-webrtc/blob/develop/scripts/ros_webrtc_rosbridge
is not called in https://github.com/mayfieldrobotics/ros-webrtc/blob/develop/ros_webrtc.launch and that the comment at the top of the first file seems a bit out of date. Wasn't sure if I should remove it, but figured you'd like to know. 

Cheers,
Peregrine