### PR TITLE
PM-2321, Increase Polling Frequency

### DIFF
--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
 
     MemMonitor monitor(NULL);
     ros::Timer mem_timer = nh.createTimer(
-        ros::Duration(1.0), monitor
+        ros::Duration(0.1), monitor
     );
     mem_timer.start();
 


### PR DESCRIPTION
We've still seen OOMs with this monitoring code, meaning the memory usage is spiking FASTER than the once per second threshold can catch it. Try increasing the frequency the check is run, which should hopefully both capture the leak and prevent the OOM.

This has been run on a13 for a while, but it didn't have the memory spike while that happened.

I'm not sure if we want to put this on the 0.64.2 or wait till after SxSW...