### PR TITLE
Add support for madmux video stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ find_package(catkin REQUIRED COMPONENTS
   bondcpp
 )
 
+set(USE_MADMUX false CACHE BOOL "use madmux")
+if(USE_MADMUX)
+    find_package(madmux REQUIRED)
+    add_definitions("-DUSE_MADMUX")
+endif()
+
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 find_package(PkgConfig REQUIRED COMPONENTS system)
@@ -150,6 +156,7 @@ include_directories(
   ${jingle_INCLUDE_DIRS}
   ${jsoncpp_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
+  ${madmux_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
@@ -185,6 +192,7 @@ target_link_libraries(ros_webrtc_host
   ${jsoncpp_STATIC_LDFLAGS}
   ${OpenCV_LIBRARIES}
   ${CMAKE_DL_LIBS}
+  ${madmux_LIBRARIES}
 )
 
 ## Specify additional compile flags

--- a/src/cpp/config.cpp
+++ b/src/cpp/config.cpp
@@ -152,6 +152,9 @@ bool Config::_get(ros::NodeHandle& nh, const std::string& root, VideoSource& val
     } else if (value.name.find("ros://") == 0) {
         value.name = value.name.substr(6);
         value.type = VideoSource::ROSType;
+    } else if (value.name.find("madmux://") == 0) {
+        value.name = value.name.substr(9);
+        value.type = VideoSource::MuxType;
     } else {
         value.type = VideoSource::NameType;
     }

--- a/src/cpp/host.cpp
+++ b/src/cpp/host.cpp
@@ -362,6 +362,11 @@ bool Host::_open_media() {
         _video_capture_modules,
         ros_video_capture_topics
     );
+#ifdef USE_MADMUX
+    GeoVideoDeviceCapturerFactory geo_video_capturer_factory(
+        _video_capture_modules
+    );
+#endif
     cricket::WebRtcVideoDeviceCapturerFactory *video_capturer_factory = NULL;
     for (size_t i = 0; i != _video_srcs.size(); i++) {
         VideoSource& video_src = _video_srcs[i];
@@ -387,6 +392,16 @@ bool Host::_open_media() {
                 video_capturer_factory = &webrtc_video_capturer_factory;
                 break;
             }
+#ifdef USE_MADMUX
+            case VideoSource::MuxType: {
+                ROS_INFO("yeeee %s", video_src.name.c_str());
+                auto video0 = webrtc_video_capture_devices.begin();
+                device.id = video0->unique_id;
+                device.name = video0->name;
+                video_capturer_factory = &geo_video_capturer_factory;
+                break;
+            }
+#endif
             case VideoSource::IdType: {
                 auto j = std::find_if(
                     webrtc_video_capture_devices.begin(),

--- a/src/cpp/host.h
+++ b/src/cpp/host.h
@@ -28,7 +28,8 @@ struct VideoSource {
     enum Type {
         NameType = 0,
         IdType,
-        ROSType
+        ROSType,
+        MuxType,
     };
 
     VideoSource();


### PR DESCRIPTION
If `-DUSE_MADMUX` is given to `cmake`/`catkin_make`, it will look for it (and error out if not found) and activate support for our new camera.

See https://github.com/mayfieldrobotics/madmux for more info on `madmux`

Bonus points: no proprietary code in a public repo :)