### PR TITLE
Fix typo causing incomplete ice server config

### DIFF
--- a/src/cpp/config.cpp
+++ b/src/cpp/config.cpp
@@ -47,7 +47,7 @@ Config Config::get(ros::NodeHandle& nh) {
     if (nh.getParam("ice_servers", ice_servers_xml)) {
         for (size_t i = 0; i != ice_servers_xml.size(); i++) {
             webrtc::PeerConnectionInterface::IceServer ice_server;
-            if (_get(nh, ice_servers_xml[0], ice_server)) {
+            if (_get(nh, ice_servers_xml[i], ice_server)) {
                 instance.ice_servers.push_back(ice_server);
             }
         }


### PR DESCRIPTION
Once upon a time, there were two ice servers. Together, they shared the load in handling WebRTC connections. One day, we think one of the ice servers stopped working. An engineer was called and began trying to diagnose why one of the ice servers wasn't working. The engineer fed all of the WebRTC connections to a single ice server, and when that didn't work, additional ice servers were added to help service the traffic.

Suddenly, the engineer heard a commotion in the hallway and went to investigate...

...three years later, a different engineer came poking around trying to troubleshoot why the ice servers weren't working. Luckily, this engineer loved the number 0 and couldn't help but fixate on zeros, wherever they manifested. Aren't zeros fascinating? While examining one of these beloved characters more closely, the engineer discovered a solitary misplaced zero. Uh oh! This zero had been blocking all but the first ice server from handling WebRTC connections. The long years had been unfriendly to the single ice server and in its old age, it had become unresponsive to requests that it couldn't identify. The engineer, feeling for the lone ice server, retired it, and begrudgingly removed the errant zero.

Immediately, WebRTC connections began to rush in, dispersing themselves among the many ice servers. All of the ice servers were once again being used and the engineer had solved a problem. All the adorable home robots (and their owners who wanted to check in on them) lived happily ever after.

The end.